### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@
 
 A **simplified Model Context Protocol (MCP)** server for **raw Markdown content** access. This server provides a single powerful tool for accessing raw Markdown files or combining multiple files from directories without any processing or parsing.
 
+<a href="https://glama.ai/mcp/servers/@hendrickcastro/MCPContentEngineering">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@hendrickcastro/MCPContentEngineering/badge" alt="ContentEngineering MCP server" />
+</a>
+
 ## 🚀 Quick Start
 
 ### Prerequisites


### PR DESCRIPTION
This PR adds a badge for the [MCP ContentEngineering](https://glama.ai/mcp/servers/@hendrickcastro/MCPContentEngineering) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@hendrickcastro/MCPContentEngineering">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@hendrickcastro/MCPContentEngineering/badge" alt="ContentEngineering MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.